### PR TITLE
fix(sse): update SSE handler to require trailing slash for proper routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ func main() {
 	}
 	
 	// Register the handler with your HTTP server
-	http.Handle("/sse", handler)
+	// We need trailing slash to handle all under `/sse/` with SSE handler
+	http.Handle("/sse/", handler)
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 ```


### PR DESCRIPTION
I investigated #39 and found we need a trailing slash when registering SSE handler.
This PR adds tests with `http.ServeMux` and fixes README.